### PR TITLE
Gene node attributes file bug fixes

### DIFF
--- a/cellmaps_imagedownloader/gene.py
+++ b/cellmaps_imagedownloader/gene.py
@@ -650,16 +650,15 @@ class ImageGeneNodeAttributeGenerator(GeneNodeAttributeGenerator):
         #gene node attributes and filtering is by GENE SYMBOL, column has associated ensembl ID(s) to keep track
         for x in query_res:
 
-            # skips item that lacks a symbol like this one:
+            # use ensembl ID for symbol if item lacks a symbol like this one:
             # {'query': 'ENSG00000282988',
             #  '_id': 'ENSG00000282988',
             #  '_score': 25.04868,
             #  'ensembl': {'gene': 'ENSG00000282988'}}
             if 'symbol' not in x:
-                errors.append('Skipping ' + str(x) +
-                              ' no symbol in query result: ' + str(x))
-                logger.error(errors[-1])
-                continue
+                symbol = x['query']
+            else:
+                symbol = x['symbol']
                 
             # skips item that lacks anything like this one:
             # {'query': 'ENSG000001', 'notfound': True}
@@ -671,15 +670,15 @@ class ImageGeneNodeAttributeGenerator(GeneNodeAttributeGenerator):
                 
             if x['query'] in query_symbol_dict:
                 continue #duplicate query, just take first result
-            query_symbol_dict[x['query']] = x['symbol']
+            query_symbol_dict[x['query']] = symbol
             
-            if x['symbol'] not in symbol_query_dict: 
-                symbol_query_dict[x['symbol']] = set()
-            symbol_query_dict[x['symbol']].add(x['query'])
+            if symbol not in symbol_query_dict: 
+                symbol_query_dict[symbol] = set()
+            symbol_query_dict[symbol].add(x['query'])
             
                         
-            if x['symbol'] not in symbol_ensembl_dict:
-                symbol_ensembl_dict[x['symbol']] = set() 
+            if symbol not in symbol_ensembl_dict:
+                symbol_ensembl_dict[symbol] = set() 
             # check if item 'ensembl' has more then 1 element, add list of ensembl genes to link gene symbol to ensemble IDs for the nodes table
             #
             # {'query': 'ENSG00000273706',
@@ -690,9 +689,9 @@ class ImageGeneNodeAttributeGenerator(GeneNodeAttributeGenerator):
             if len(x['ensembl']) > 1:
                 for g in x['ensembl']:
                     # concatenate ensembl ids and delimit with ;
-                    symbol_ensembl_dict[x['symbol']].add(g['gene'])
+                    symbol_ensembl_dict[symbol].add(g['gene'])
             else:
-                symbol_ensembl_dict[x['symbol']].add(x['ensembl']['gene'])
+                symbol_ensembl_dict[symbol].add(x['ensembl']['gene'])
 
         #loop through unique gene symbols, make gene nodes attribute file
         gene_node_attrs = {}

--- a/cellmaps_imagedownloader/gene.py
+++ b/cellmaps_imagedownloader/gene.py
@@ -581,7 +581,7 @@ class ImageGeneNodeAttributeGenerator(GeneNodeAttributeGenerator):
                                    sample['sample'] + '_')
             for g in ensembl_ids:
                 #if gene already has nonambgiuous antibody, use that one
-                if antibody in g_antibody_dict:
+                if g in g_antibody_dict:
                     if antibody in ambiguous_antibody_dict:
                         continue
                 g_antibody_dict[g] = antibody

--- a/tests/test_imagegenenodegenerator.py
+++ b/tests/test_imagegenenodegenerator.py
@@ -467,8 +467,6 @@ class TestImageGeneNodeAttributeGenerator(unittest.TestCase):
                                                    genequery=mockgenequery)
 
         res = imagegen.get_gene_node_attributes()
-        print('TEST_LEAH')
-        print(res)
         self.assertEqual('ENSG1,ENSG2', res[0]['geneA']['represents'])
 
         # check we got no error

--- a/tests/test_imagegenenodegenerator.py
+++ b/tests/test_imagegenenodegenerator.py
@@ -287,7 +287,7 @@ class TestImageGeneNodeAttributeGenerator(unittest.TestCase):
 
         self.assertEqual({'antibody_one': {'1_A1_2_'},
                           'antibody_two': {'3_B1_4_'}}, filename_dict)
-        self.assertEqual({'antibody_two': 'ensemble_two,ensemble_three'}, ambig_dict)
+        self.assertEqual({'antibody_two': ['ensemble_two', 'ensemble_three']}, ambig_dict)
 
     def test_get_unique_ids_from_samplelist(self):
 
@@ -352,13 +352,13 @@ class TestImageGeneNodeAttributeGenerator(unittest.TestCase):
         gene_node_attrs = res[0]
         print(gene_node_attrs)
         print('\n\n\n\n')
-        self.assertTrue('ENSG00000066455' in gene_node_attrs)
-        self.assertEqual('GOLGA5', gene_node_attrs['ENSG00000066455']['name'])
-        self.assertEqual('ensembl:ENSG00000066455', gene_node_attrs['ENSG00000066455']['represents'])
-        self.assertTrue(gene_node_attrs['ENSG00000066455']['filename'] == '1_A1_2_' or
-                        gene_node_attrs['ENSG00000066455']['filename'] == '1_A1_1_')
+        self.assertTrue('GOLGA5' in gene_node_attrs)
+        self.assertEqual('GOLGA5', gene_node_attrs['GOLGA5']['name'])
+        self.assertEqual('ENSG00000066455', gene_node_attrs['GOLGA5']['represents'])
+        self.assertTrue(gene_node_attrs['GOLGA5']['filename'] == '1_A1_2_' or
+                        gene_node_attrs['GOLGA5']['filename'] == '1_A1_1_')
 
-        self.assertTrue('ENSG00000183092' in gene_node_attrs)
+        self.assertTrue('GOLGA5' in gene_node_attrs)
 
         # check errors is empty
         self.assertEqual([], res[1])
@@ -448,11 +448,11 @@ class TestImageGeneNodeAttributeGenerator(unittest.TestCase):
                     'position': 'A1',
                     'sample': '1',
                     'antibody': 'HPA000992',
-                    'ensembl_ids': 'ENSG1',
-                    'gene_names': 'XXX'}]
+                    'ensembl_ids': 'ENSG1,ENSG2',
+                    'gene_names': 'geneA'}]
         unique = [{'antibody': 'HPA000992',
-                   'ensembl_ids': 'ENSG1',
-                   'gene_names': 'XXX'}]
+                   'ensembl_ids': 'ENSG1,ENSG2',
+                   'gene_names': 'geneA'}]
 
         mockgenequery = MagicMock()
         mockgenequery.get_symbols_for_genes = MagicMock(return_value=[{'query': 'ENSG1',
@@ -460,14 +460,16 @@ class TestImageGeneNodeAttributeGenerator(unittest.TestCase):
                                                                        '_score': 24.515644,
                                                                        'ensembl': [{'gene': 'ENSG1'},
                                                                                    {'gene': 'ENSG2'}],
-                                                                       'symbol': 'XXX'}])
+                                                                       'symbol': 'geneA'}])
 
         imagegen = ImageGeneNodeAttributeGenerator(samples_list=samples,
                                                    unique_list=unique,
                                                    genequery=mockgenequery)
 
         res = imagegen.get_gene_node_attributes()
-        self.assertEqual('ensembl:ENSG1;ENSG2', res[0]['ENSG1']['represents'])
+        print('TEST_LEAH')
+        print(res)
+        self.assertEqual('ENSG1,ENSG2', res[0]['geneA']['represents'])
 
         # check we got no error
         self.assertEqual(0, len(res[1]))

--- a/tests/test_imagegenenodegenerator.py
+++ b/tests/test_imagegenenodegenerator.py
@@ -376,18 +376,23 @@ class TestImageGeneNodeAttributeGenerator(unittest.TestCase):
 
         mockgenequery = MagicMock()
         mockgenequery.get_symbols_for_genes = MagicMock(return_value=[{'query': 'ENSG1',
-                                                                       'notfound': True}])
+                                                                       '_id': '9950',
+                                                                       '_score': 25.046944,
+                                                                       'ensembl': {'gene':'ENSG1'},
+                                                                       }])
 
         imagegen = ImageGeneNodeAttributeGenerator(samples_list=samples,
                                                    unique_list=unique,
                                                    genequery=mockgenequery)
 
         res = imagegen.get_gene_node_attributes()
-        self.assertEqual({}, res[0])
+        gene_node_attrs = res[0]
 
-        # check we got an error
-        self.assertTrue(1, len(res[1]))
-        self.assertTrue('no symbol in query result' in res[1][0])
+        self.assertTrue('ENSG1' in gene_node_attrs)
+        self.assertEqual('ENSG1', gene_node_attrs['ENSG1']['name'])
+        self.assertEqual('ENSG1', gene_node_attrs['ENSG1']['represents'])
+        self.assertTrue(gene_node_attrs['ENSG1']['filename'] == '1_A1_2_' or
+                        gene_node_attrs['ENSG1']['filename'] == '1_A1_1_')
 
     def test_get_gene_node_attributes_no_ensembl(self):
         samples = [{'if_plate_id': '1',
@@ -402,7 +407,7 @@ class TestImageGeneNodeAttributeGenerator(unittest.TestCase):
 
         mockgenequery = MagicMock()
         mockgenequery.get_symbols_for_genes = MagicMock(return_value=[{'query': 'ENSG1',
-                                                                       'symbol': 'XXX',
+                                                                       'notfound': True,
                                                                        }])
 
         imagegen = ImageGeneNodeAttributeGenerator(samples_list=samples,


### PR DESCRIPTION
The bug was the for loop for adding gene node attributes should loop a gene_symbol dictionary, not the query output. Noticed there were duplicate entries and missing gene names, related to ambiguous antibodies. The HPA inputs have ensemblIDs but these ensemble ID's are treated as queries, and the result from the mygene analysis will be the final gene symbol and ensembl IDs listed in the table